### PR TITLE
fix(home): render homepage dynamically to avoid stale empty CMS cache

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,8 @@ import { ProjectCard } from "@/components/project-card"
 import { profileData } from "@/data"
 import { getFeaturedProjects, getLatestPosts } from "@/lib/cms/strapi"
 
+export const dynamic = "force-dynamic"
+
 export const metadata: Metadata = {
   title: "Marwan Baz - Web Engineer  | Next.js & React ",
   description: "Explore the website of Marwan Baz, a Frontend Developer specializing in Next.js, React, and modern web technologies. View projects and learn about my skills in web development.",


### PR DESCRIPTION
## Summary\n- re-add  on homepage\n- prevent home from being cached with empty CMS data when Strapi returns temporary 503\n\n## Why\nProduction showed empty Latest Articles and featured projects due to temporary Strapi 503 plus static homepage cache snapshot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the homepage dynamically to avoid serving empty CMS content when Strapi returns a temporary 503. Prevents the static cache from snapshotting an empty state for Latest Articles and Featured Projects.

- **Bug Fixes**
  - Force dynamic rendering for `/` with `export const dynamic = "force-dynamic"`, bypassing static snapshots when the CMS is down.

<sup>Written for commit 5270fa319c19f8d6be9b506558999b44fa2811ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

