### PR TITLE
fix(work): restore featured-only case study links

### DIFF
--- a/src/app/work/work-client.tsx
+++ b/src/app/work/work-client.tsx
@@ -29,7 +29,9 @@ export function WorkClient({ projects }: { projects: CmsProject[] }) {
                 githubUrl={project.sourceCode || undefined}
                 liveUrl={project.liveDemo || undefined}
                 isFeatured={project.isFeatured}
-                projectUrl={`/work/${project.slug}`}
+                projectUrl={
+                  project.isFeatured ? `/work/${project.slug}` : undefined
+                }
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- restore previous work-page behavior where only featured projects navigate to case studies
- keep non-featured cards visible but non-clickable

## Change
- in work client grid, pass project URL only when project.isFeatured is true

## Validation
- manual code path verification completed
- lint could not run in this temp worktree because dependencies are not installed (eslint not found)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the work page behavior so only featured projects link to their case studies. Non-featured cards remain visible but are not clickable.

- **Bug Fixes**
  - In `work-client.tsx`, set `projectUrl` only when `project.isFeatured` is true.

<sup>Written for commit a65a2a3d11d7587086b0fc1b0320886d7b8c0413. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

