### PR TITLE
Develop

### DIFF
--- a/src/app/work/work-client.tsx
+++ b/src/app/work/work-client.tsx
@@ -29,7 +29,9 @@ export function WorkClient({ projects }: { projects: CmsProject[] }) {
                 githubUrl={project.sourceCode || undefined}
                 liveUrl={project.liveDemo || undefined}
                 isFeatured={project.isFeatured}
-                projectUrl={`/work/${project.slug}`}
+                projectUrl={
+                  project.isFeatured ? `/work/${project.slug}` : undefined
+                }
               />
             ))}
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Only featured projects in the Work grid now link to their case studies; non-featured cards are no longer clickable. This restores the intended behavior and prevents navigation to missing or unpublished pages.

<sup>Written for commit 6525dc13b791a8b53c8dc70b1564f6d86b70acd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

