### PR TITLE
Refine project case studies with scene gallery and concise copy

### DIFF
--- a/src/components/project-scene-gallery.tsx
+++ b/src/components/project-scene-gallery.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { Expand } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { cn } from "@/lib/utils"
+import Image from "next/image"
+import { useState } from "react"
+
+export interface ProjectScene {
+  description?: string
+  label: string
+  title: string
+  url: string
+}
+
+export function ProjectSceneGallery({
+  projectTitle,
+  scenes,
+}: {
+  projectTitle: string
+  scenes: ProjectScene[]
+}) {
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  if (scenes.length === 0) {
+    return null
+  }
+
+  const activeScene = scenes[activeIndex]
+
+  return (
+    <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
+      <div className="overflow-hidden rounded-[30px] border border-border/70 bg-background shadow-sm">
+        <div className="relative aspect-[16/10] w-full bg-muted/30">
+          <Image
+            src={activeScene.url}
+            alt={`${projectTitle} ${activeScene.title}`}
+            fill
+            priority={activeIndex === 0}
+            sizes="(min-width: 1280px) 960px, 100vw"
+            className="object-cover object-top"
+          />
+        </div>
+
+        <div className="flex flex-col gap-4 border-t border-border/70 px-5 py-5 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-3">
+            <Badge
+              variant="outline"
+              className="rounded-full px-3 py-1 text-[10px] uppercase tracking-[0.18em]"
+            >
+              {activeScene.label}
+            </Badge>
+            <div className="space-y-1">
+              <h2 className="text-2xl font-semibold tracking-tight">{activeScene.title}</h2>
+              {activeScene.description && (
+                <p className="max-w-2xl text-sm text-muted-foreground md:text-base">
+                  {activeScene.description}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button size="sm" variant="outline">
+                <Expand className="h-4 w-4" />
+                Expand
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-5xl border-border/70 bg-background p-3 sm:p-4">
+              <DialogHeader className="pr-10">
+                <DialogTitle>{activeScene.title}</DialogTitle>
+                {activeScene.description && (
+                  <DialogDescription>{activeScene.description}</DialogDescription>
+                )}
+              </DialogHeader>
+              <div className="relative aspect-[16/10] w-full overflow-hidden rounded-[24px] border border-border/70 bg-muted/30">
+                <Image
+                  src={activeScene.url}
+                  alt={`${projectTitle} ${activeScene.title}`}
+                  fill
+                  sizes="90vw"
+                  className="object-contain"
+                />
+              </div>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      {scenes.length > 1 && (
+        <div className="rounded-[30px] border border-border/70 bg-background p-3 shadow-sm">
+          <div className="mb-3 px-2 pt-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              Gallery
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+            {scenes.map((scene, index) => (
+              <button
+                key={`${scene.url}-${index}`}
+                type="button"
+                onClick={() => setActiveIndex(index)}
+                className={cn(
+                  "flex items-center gap-3 rounded-[22px] border border-transparent p-2 text-left transition-colors",
+                  "hover:border-border/70 hover:bg-muted/30",
+                  index === activeIndex && "border-border/70 bg-muted/40"
+                )}
+              >
+                <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded-2xl border border-border/60 bg-muted/30">
+                  <Image
+                    src={scene.url}
+                    alt={`${projectTitle} ${scene.title}`}
+                    fill
+                    sizes="96px"
+                    className="object-cover object-top"
+                  />
+                </div>
+                <div className="min-w-0 space-y-1">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    {scene.label}
+                  </p>
+                  <p className="truncate text-sm font-medium text-foreground">{scene.title}</p>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/project-scene-gallery.tsx
+++ b/src/components/project-scene-gallery.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
 import Image from "next/image"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 export interface ProjectScene {
   description?: string
@@ -31,6 +31,12 @@ export function ProjectSceneGallery({
   scenes: ProjectScene[]
 }) {
   const [activeIndex, setActiveIndex] = useState(0)
+
+  useEffect(() => {
+    if (activeIndex >= scenes.length) {
+      setActiveIndex(0)
+    }
+  }, [activeIndex, scenes.length])
 
   if (scenes.length === 0) {
     return null

--- a/src/components/project-showcase.tsx
+++ b/src/components/project-showcase.tsx
@@ -2,8 +2,82 @@ import { ExternalLink, Github } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ProjectSceneGallery, type ProjectScene } from "@/components/project-scene-gallery"
 import type { CmsProject } from "@/lib/cms/types"
-import Image from "next/image"
+
+const categoryLabels: Record<CmsProject["category"], string> = {
+  web: "Web app",
+  mobile: "Mobile app",
+}
+
+function normalizeAssetKey(url: string) {
+  return url.trim().replace(/\/+$/, "")
+}
+
+function buildScenes(project: CmsProject): ProjectScene[] {
+  const seenKeys = new Set<string>()
+  const scenes: ProjectScene[] = []
+
+  const pushScene = (scene: ProjectScene | null) => {
+    if (!scene) {
+      return
+    }
+
+    const assetKey = normalizeAssetKey(scene.url)
+    if (!assetKey || seenKeys.has(assetKey)) {
+      return
+    }
+
+    seenKeys.add(assetKey)
+    scenes.push(scene)
+  }
+
+  pushScene(
+    project.imageUrl
+      ? {
+          description: "",
+          label: "01",
+          title: "Overview",
+          url: project.imageUrl,
+        }
+      : null
+  )
+
+  project.screenshots.forEach((screenshot, index) => {
+    pushScene(
+      screenshot.url
+        ? {
+            description: screenshot.caption || "",
+            label: String(index + 2).padStart(2, "0"),
+            title: screenshot.caption || `Screen ${index + 1}`,
+            url: screenshot.url,
+          }
+        : null
+    )
+  })
+
+  return scenes
+}
+
+function CompactList({
+  items,
+}: {
+  items: string[]
+}) {
+  return (
+    <ul className="grid gap-3">
+      {items.map((item, index) => (
+        <li
+          key={`${item}-${index}`}
+          className="rounded-2xl border border-border/60 bg-background px-4 py-3 text-sm text-foreground shadow-sm"
+        >
+          {item}
+        </li>
+      ))}
+    </ul>
+  )
+}
 
 export function ProjectShowcase({ project }: { project: CmsProject }) {
   const {
@@ -12,156 +86,203 @@ export function ProjectShowcase({ project }: { project: CmsProject }) {
     coreFunctionalities,
     role,
     technologies,
+    category,
     liveDemo,
     sourceCode,
     purpose,
     expectedOutcome,
-    initialDesigns,
     spotlightFeature,
+    currentStatus,
     technicalChallenges,
     solutions,
-    currentStatus,
+    impact,
     lessonsLearned,
     frameworkExperience,
     accessibilityLearnings,
-    impact,
-    screenshots,
   } = project
 
+  const scenes = buildScenes(project)
+  const topMeta = [
+    { label: "Role", value: role },
+    { label: "Platform", value: categoryLabels[category] },
+    { label: "Status", value: currentStatus?.users || "" },
+  ].filter((item) => item.value)
+
   return (
-    <article className="max-w-4xl mx-auto space-y-8 p-6 pt-40 md:pt-48">
-      <header className="text-center">
-        <h1 className="text-4xl font-bold mb-4">{title}</h1>
-        <p className="text-xl text-gray-600 dark:text-gray-300 mb-6">{summary}</p>
-        <div className="flex flex-wrap justify-center gap-2 mb-6">
+    <article className="mx-auto max-w-6xl px-4 pb-24 pt-32 md:px-6 md:pt-40">
+      <header className="space-y-6">
+        <div className="space-y-4">
+          <Badge
+            variant="outline"
+            className="w-fit rounded-full border-border/80 px-3 py-1 uppercase tracking-[0.18em] text-[10px] text-muted-foreground"
+          >
+            {categoryLabels[category]}
+          </Badge>
+
+          <div className="space-y-4">
+            <h1 className="max-w-4xl text-4xl font-semibold tracking-tight md:text-5xl lg:text-6xl">
+              {title}
+            </h1>
+            <p className="max-w-3xl text-base leading-7 text-muted-foreground md:text-lg">
+              {summary}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
           {technologies.map((tech, index) => (
-            <Badge key={index} variant="secondary">
+            <Badge
+              key={`${tech}-${index}`}
+              variant="outline"
+              className="rounded-full border-border/70 bg-background px-3 py-1"
+            >
               {tech}
             </Badge>
           ))}
         </div>
-        <div className="flex justify-center gap-4">
+
+        <div className="flex flex-wrap gap-3">
           {liveDemo && (
-            <Button asChild>
+            <Button size="sm" asChild>
               <a href={liveDemo} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="mr-2 h-4 w-4" /> Live Demo
+                <ExternalLink className="h-4 w-4" />
+                Live
               </a>
             </Button>
           )}
           {sourceCode && (
-            <Button variant="outline" asChild>
+            <Button size="sm" variant="outline" asChild>
               <a href={sourceCode} target="_blank" rel="noopener noreferrer">
-                <Github className="mr-2 h-4 w-4" /> Source Code
+                <Github className="h-4 w-4" />
+                Code
               </a>
             </Button>
           )}
         </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {topMeta.map((item) => (
+            <div
+              key={item.label}
+              className="rounded-[24px] border border-border/70 bg-background px-5 py-4 shadow-sm"
+            >
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                {item.label}
+              </p>
+              <p className="mt-2 text-sm font-medium text-foreground md:text-base">{item.value}</p>
+            </div>
+          ))}
+        </div>
       </header>
 
-      <section>
-        <h2 className="text-2xl font-semibold mb-4">Introduction</h2>
-        <ul className="list-disc pl-6 space-y-2">
-          {coreFunctionalities.map((functionality, index) => (
-            <li key={index}>{functionality}</li>
-          ))}
-        </ul>
-        <p className="mt-4">
-          <strong>My Role:</strong> {role}
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-2xl font-semibold mb-4">Purpose and Goal</h2>
-        <p className="mb-4">{purpose}</p>
-        <p className="mb-4">
-          <strong>Expected Outcome:</strong> {expectedOutcome}
-        </p>
-        <h3 className="text-xl font-semibold mb-2">Initial Designs</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {initialDesigns.map((design, index) => (
-            <Image
-              key={index}
-              src={design || "/placeholder.svg"}
-              alt={`Initial design ${index + 1}`}
-              width={400}
-              height={300}
-              className="rounded-lg shadow-md"
-            />
-          ))}
+      {scenes.length > 0 && (
+        <div className="mt-8">
+          <ProjectSceneGallery projectTitle={title} scenes={scenes} />
         </div>
-      </section>
-
-      <section>
-        <h2 className="text-2xl font-semibold mb-4">Spotlight Feature</h2>
-        <h3 className="text-xl font-semibold mb-2">{spotlightFeature.title}</h3>
-        <p>{spotlightFeature.description}</p>
-        <h3 className="text-xl font-semibold mt-4 mb-2">Technical Challenges</h3>
-        <ul className="list-disc pl-6 space-y-2">
-          {technicalChallenges.map((challenge, index) => (
-            <li key={index}>{challenge}</li>
-          ))}
-        </ul>
-        <h3 className="text-xl font-semibold mt-4 mb-2">Solutions</h3>
-        <ul className="list-disc pl-6 space-y-2">
-          {solutions.map((solution, index) => (
-            <li key={index}>{solution}</li>
-          ))}
-        </ul>
-      </section>
-
-      {currentStatus && (
-        <section>
-          <h2 className="text-2xl font-semibold mb-4">Current Status</h2>
-          <p>
-            <strong>Users:</strong> {currentStatus.users}
-          </p>
-          <p>
-            <strong>Feedback:</strong> {currentStatus.feedback}
-          </p>
-        </section>
       )}
 
-      <section>
-        <h2 className="text-2xl font-semibold mb-4">Lessons Learned</h2>
-        <ul className="list-disc pl-6 space-y-2">
-          {lessonsLearned.map((lesson, index) => (
-            <li key={index}>{lesson}</li>
-          ))}
-        </ul>
-        {frameworkExperience && (
-          <p className="mt-4">
-            <strong>Framework Experience:</strong> {frameworkExperience}
-          </p>
-        )}
-        {accessibilityLearnings && (
-          <p className="mt-4">
-            <strong>Accessibility Learnings:</strong> {accessibilityLearnings}
-          </p>
-        )}
-        <p className="mt-4">
-          <strong>Impact on Future Work:</strong> {impact}
-        </p>
-      </section>
+      <div className="mt-8 grid gap-6 lg:grid-cols-2">
+        <Card className="rounded-[28px] border-border/70 shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-2xl tracking-tight">Overview</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm leading-7 text-muted-foreground">
+            <p>{purpose}</p>
+            <div className="rounded-2xl border border-border/60 bg-muted/30 p-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Goal
+              </p>
+              <p className="mt-2 text-sm text-foreground">{expectedOutcome}</p>
+            </div>
+          </CardContent>
+        </Card>
 
-      <section>
-        <h2 className="text-2xl font-semibold mb-4">Project Gallery</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {screenshots.map((screenshot, index) => (
-            <figure key={index} className="space-y-2">
-              <Image
-                src={screenshot.url || "/placeholder.svg"}
-                alt={screenshot.caption}
-                width={600}
-                height={400}
-                className="rounded-lg shadow-md"
-              />
-              <figcaption className="text-sm text-center text-gray-600 dark:text-gray-400">
-                {screenshot.caption}
-              </figcaption>
-            </figure>
-          ))}
-        </div>
-      </section>
+        <Card className="rounded-[28px] border-border/70 shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-2xl tracking-tight">What I Built</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {(spotlightFeature.title || spotlightFeature.description) && (
+              <div className="rounded-2xl border border-border/60 bg-muted/30 p-4">
+                {spotlightFeature.title && (
+                  <p className="text-sm font-medium text-foreground">{spotlightFeature.title}</p>
+                )}
+                {spotlightFeature.description && (
+                  <p className="mt-2 text-sm leading-7 text-muted-foreground">
+                    {spotlightFeature.description}
+                  </p>
+                )}
+              </div>
+            )}
+            <CompactList items={coreFunctionalities} />
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-[28px] border-border/70 shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-2xl tracking-tight">Challenges</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CompactList items={technicalChallenges} />
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-[28px] border-border/70 shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-2xl tracking-tight">Solutions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CompactList items={solutions} />
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-[28px] border-border/70 shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-2xl tracking-tight">Impact</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm leading-7 text-muted-foreground">
+            <p>{impact}</p>
+            {currentStatus?.feedback && (
+              <div className="rounded-2xl border border-border/60 bg-muted/30 p-4">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  Feedback
+                </p>
+                <p className="mt-2 text-sm text-foreground">{currentStatus.feedback}</p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-[28px] border-border/70 shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-2xl tracking-tight">What I Learned</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <CompactList items={lessonsLearned} />
+
+            {(frameworkExperience || accessibilityLearnings) && (
+              <div className="grid gap-4">
+                {frameworkExperience && (
+                  <div className="rounded-2xl border border-border/60 bg-muted/30 p-4">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      Framework
+                    </p>
+                    <p className="mt-2 text-sm text-foreground">{frameworkExperience}</p>
+                  </div>
+                )}
+                {accessibilityLearnings && (
+                  <div className="rounded-2xl border border-border/60 bg-muted/30 p-4">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      Accessibility
+                    </p>
+                    <p className="mt-2 text-sm text-foreground">{accessibilityLearnings}</p>
+                  </div>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </article>
   )
 }


### PR DESCRIPTION
## Summary
- replace the long-form project detail page copy with concise, portfolio-style section titles
- introduce a shadcn-style scene gallery with selectable thumbnails and expand-to-dialog view
- keep existing CMS/data contracts intact while deduplicating visual scenes in the UI layer

## Testing
- npm run lint
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks project case studies with a scene-based gallery and concise, scannable copy. Adds a new `ProjectSceneGallery` and refactors `ProjectShowcase` into a clean card layout without changing CMS contracts.

- **New Features**
  - Added `ProjectSceneGallery` with selectable thumbnails and an expand-to-dialog view.
  - Built scenes from `CmsProject` hero and screenshots; deduped by URL in the UI layer.
  - Refactored `ProjectShowcase` to a card-based layout with clear section titles, tech badges, and quick links.
  - Introduced compact meta (Role, Platform, Status) and trimmed long-form copy into short, readable blocks.

- **Bug Fixes**
  - Guarded `ProjectSceneGallery` active index when scenes change to prevent out-of-bounds across project navigation.

<sup>Written for commit b0be5d1712bce2121cda3003ae80be1a03834205. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

